### PR TITLE
CircleCI で gh-pages ブランチを clone して処理する

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@ deployment:
   gh-pages:
     branch: master
     commands:
-      - git clone git@github.com:leckyyyyyyy/gh-pages-test.git public
+      - git clone -b gh-pages git@github.com:leckyyyyyyy/gh-pages-test.git public
       - hugo
       - cd public && git add .
-      - cd public && git commit -m "[ci skip] publish `date '+%Y/%m/%d %H:%M:%S'`"
+      - cd public && git commit -m "publish `date '+%Y/%m/%d %H:%M:%S'`"
       - cd public && git push origin gh-pages

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
.gitignore に public フォルダを設定しているため、そのままでは `hugo` を実行しても
生成したページを commit できないと思います。
clone するとき `gh-pages` ブランチを指定して public フォルダに書き出すように設定し
commit すれば `gh-pages` ブランチのリポジトリで反映されるのではないかと思います。

`hugo` を実行したときに `Unable to find Static Directory` と表示されたので、追加しても影響の無い
`static/robots.txt` を追加しました。
